### PR TITLE
Add lazy loading rules

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,8 +1,38 @@
 /* global hbspt */
 module.exports = (eleventyConfig, options = {}) => {
+
+    const hsScripts = {
+        forms: {
+            id: crypto.randomUUID(),
+            src: "https://js.hsforms.net/forms/embed/v2.js"
+        },
+        meetings: {
+            id: crypto.randomUUID(),
+            src: "https://static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"
+        }
+    };
+
     if (!options.portalId) {
         throw new Error(
             "[eleventy-plugin-hubspot] the portalId must be specified in plugin options"
+        );
+    }
+
+    let loadingMode = options.loadingMode || null;
+
+    // if no value set default to default
+    if (!loadingMode) {
+        loadingMode = "default";
+        console.info(
+            "[eleventy-plugin-hubspot] the loadingMode is not set, defaulting to 'default'.\nYou can set it to 'lazy' or 'eager' to enable lazy loading feature,\ncheck the documentation for more details https://github.com/reatlat/eleventy-plugin-hubspot#custom-usage\n"
+        );
+    }
+
+    delete options.loadingMode;
+
+    if (!["default", "lazy", "eager"].includes(loadingMode)) {
+        throw new Error(
+            "[eleventy-plugin-hubspot] the loadingMode must be one of 'default', 'lazy', 'eager'"
         );
     }
 
@@ -26,22 +56,109 @@ module.exports = (eleventyConfig, options = {}) => {
                 "[eleventy-plugin-hubspot] the formId of hubspotForm must be specified"
             );
         }
-        
+
+        if (options.loadingMode) {
+            loadingMode = options.loadingMode;
+            delete options.loadingMode;
+            if (!["default", "lazy", "eager"].includes(loadingMode)) {
+                throw new Error(
+                    "[eleventy-plugin-hubspot] the loadingMode must be one of 'default', 'lazy', 'eager'"
+                );
+            }
+        }
+
         /**
          * How to customize the form embed code
          * @link https://legacydocs.hubspot.com/docs/methods/forms/advanced_form_options
          */
 
+        const uuid = crypto.randomUUID();
+
+        let _return = ``;
+
+        if (['eager', 'lazy'].includes(loadingMode) && !args.target) {
+            options.target = `#form-wrapper-${uuid}`;
+            _return += `<div id="form-wrapper-${uuid}"></div>`;
+        }
+
         const config = { ...options, formId, ...args };
         const encodedConfig = encodeURIComponent(JSON.stringify(config));
 
+
+        /* Lazy loading ****************************************************************************************
+        (function(window, callback){
+            callback = function(messageEvent) {
+                if (messageEvent.data === "hsFormsEmbedLoaded") {
+                    window.removeEventListener("message", callback);
+                    hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')));
+                }
+            }
+            window.addEventListener("message", callback);
+        })(window);
+        (function(w,d,options, callback, observer, target) {
+            observer = new IntersectionObserver(callback, options);
+            target = d.querySelector('${options.target}');
+            observer.observe(target);
+        })(window, document, {threshold:0.1}, function(entries, observer) {
+            if (entries[0].isIntersecting) {
+                let scriptID = "hs-script-${hsScripts.forms.id}";
+                let scriptSrc = "${hsScripts.forms.src}";
+                if (!document.getElementById(scriptID)) {
+                    const scriptElement = document.createElement("script");
+                    scriptElement.id = scriptID;
+                    scriptElement.src = scriptSrc;
+                    scriptElement.defer = true;
+                    scriptElement.onload = scriptElement.onreadystatechange = function() {
+                        if (!this.readyState || this.readyState === "loaded" || this.readyState === "complete") {
+                            scriptElement.onload = scriptElement.onreadystatechange = null;
+                            postMessage('hsFormsEmbedLoaded');
+                        }
+                    };
+                    document.body.appendChild(scriptElement);
+                }
+                observer.disconnect()
+            }
+        });
+        */
+
+        if (loadingMode === "lazy") {
+            _return += `<script type="text/javascript">/*<![CDATA[|*/(function(s,t){t=function(n){n.data==="hsFormsEmbedLoaded"&&(s.removeEventListener("message",t),hbspt.forms.create(JSON.parse(decodeURIComponent("${encodedConfig}"))))},s.addEventListener("message",t)})(window),function(s,t,n,o,e,d){e=new IntersectionObserver(o,n),d=t.querySelector("${options.target}"),e.observe(d)}(window,document,{threshold:.1},function(s,t){if(s[0].isIntersecting){let n="hs-script-${hsScripts.forms.id}",o="${hsScripts.forms.src}";if(!document.getElementById(n)){const e=document.createElement("script");e.id=n,e.src=o,e.defer=!0,e.onload=e.onreadystatechange=function(){(!this.readyState||this.readyState==="loaded"||this.readyState==="complete")&&(e.onload=e.onreadystatechange=null,postMessage("hsFormsEmbedLoaded"))},document.body.appendChild(e)}t.disconnect()}});/*]]>*/</script>`;
+            return _return;
+        }
+
+        /* Eager loading ****************************************************************************************
+        window.addEventListener("message", function(messageEvent) {
+            if (messageEvent.data === "hsFormsEmbedLoaded") {
+                hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')));
+            }
+        }, {once: true});
+        (function(window, document, scriptID, scriptSrc, scriptElement) {
+            window.addEventListener("DOMContentLoaded", function() {
+                if (!document.getElementById(scriptID)) {
+                    scriptElement = document.createElement("script");
+                    scriptElement.id = scriptID;
+                    scriptElement.src = scriptSrc;
+                    scriptElement.defer = true;
+                    scriptElement.onload = scriptElement.onreadystatechange = function() {
+                        if (!this.readyState || this.readyState === "loaded" || this.readyState === "complete") {
+                            postMessage("hsFormsEmbedLoaded");
+                            scriptElement.onload = scriptElement.onreadystatechange = null;
+                        }
+                    };
+                    document.body.appendChild(scriptElement);
+                }
+            });
+        })(window, document, "hs-script-${hsScripts.forms.id}", "${hsScripts.forms.src}");
+        */
+
+        if (loadingMode === "eager") {
+            _return += `<script type="text/javascript">/*<![CDATA[|*/window.addEventListener("message",function(d){d.data==="hsFormsEmbedLoaded"&&hbspt.forms.create(JSON.parse(decodeURIComponent("${encodedConfig}")))},{once:!0}),function(d,o,a,n,e){d.addEventListener("DOMContentLoaded",function(){o.getElementById(a)||(e=o.createElement("script"),e.id=a,e.src=n,e.defer=!0,e.onload=e.onreadystatechange=function(){(!this.readyState||this.readyState==="loaded"||this.readyState==="complete")&&(postMessage("hsFormsEmbedLoaded"),e.onload=e.onreadystatechange=null)},o.body.appendChild(e))})}(window,document,"hs-script-${hsScripts.forms.id}","${hsScripts.forms.src}");/*]]>*/</script>`;
+            return _return;
+        }
+
         return `
-            <script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
-            <script>
-                (function(config){
-                    hbspt.forms.create(JSON.parse(decodeURIComponent(config)))
-                })('${encodedConfig}')
-            </script>
+            <script charset="utf-8" type="text/javascript" src="${hsScripts.forms.src}"></script>
+            <script type="text/javascript">/*<![CDATA[|*/hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')))/*]]>*/</script>
         `;
     });
 
@@ -60,7 +177,7 @@ module.exports = (eleventyConfig, options = {}) => {
 
         return `
             <div class="meetings-iframe-container" data-src="${url.split('?')[0]}?embed=true"></div>
-            <script charset="utf-8" type="text/javascript" src="//static.hsappstatic.net/MeetingsEmbed/ex/MeetingsEmbedCode.js"></script>
+            <script id="hs-script-${hsScripts.meetings.id}" charset="utf-8" type="text/javascript" src="${hsScripts.meetings.src}"></script>
         `;
     });
 };

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -123,7 +123,7 @@ module.exports = (eleventyConfig, options = {}) => {
 
         if (loadingMode === "lazy") {
             _return += `<script type="text/javascript">/*<![CDATA[|*/(function(s,t){t=function(n){n.data==="hsFormsEmbedLoaded"&&(s.removeEventListener("message",t),hbspt.forms.create(JSON.parse(decodeURIComponent("${encodedConfig}"))))},s.addEventListener("message",t)})(window),function(s,t,n,o,e,d){e=new IntersectionObserver(o,n),d=t.querySelector("${options.target}"),e.observe(d)}(window,document,{threshold:.1},function(s,t){if(s[0].isIntersecting){let n="hs-script-${hsScripts.forms.id}",o="${hsScripts.forms.src}";if(!document.getElementById(n)){const e=document.createElement("script");e.id=n,e.src=o,e.defer=!0,e.onload=e.onreadystatechange=function(){(!this.readyState||this.readyState==="loaded"||this.readyState==="complete")&&(e.onload=e.onreadystatechange=null,postMessage("hsFormsEmbedLoaded"))},document.body.appendChild(e)}t.disconnect()}});/*]]>*/</script>`;
-            return _return;
+            return _return.replace(/\n/g, '').trim();
         }
 
         /* Eager loading ****************************************************************************************
@@ -153,13 +153,13 @@ module.exports = (eleventyConfig, options = {}) => {
 
         if (loadingMode === "eager") {
             _return += `<script type="text/javascript">/*<![CDATA[|*/window.addEventListener("message",function(d){d.data==="hsFormsEmbedLoaded"&&hbspt.forms.create(JSON.parse(decodeURIComponent("${encodedConfig}")))},{once:!0}),function(d,o,a,n,e){d.addEventListener("DOMContentLoaded",function(){o.getElementById(a)||(e=o.createElement("script"),e.id=a,e.src=n,e.defer=!0,e.onload=e.onreadystatechange=function(){(!this.readyState||this.readyState==="loaded"||this.readyState==="complete")&&(postMessage("hsFormsEmbedLoaded"),e.onload=e.onreadystatechange=null)},o.body.appendChild(e))})}(window,document,"hs-script-${hsScripts.forms.id}","${hsScripts.forms.src}");/*]]>*/</script>`;
-            return _return;
+            return _return.replace(/\n/g, '').trim();
         }
 
-        return `
-            <script charset="utf-8" type="text/javascript" src="${hsScripts.forms.src}"></script>
-            <script type="text/javascript">/*<![CDATA[|*/hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')))/*]]>*/</script>
-        `;
+        _return = `<script charset="utf-8" type="text/javascript" src="${hsScripts.forms.src}"></script><script type="text/javascript">/*<![CDATA[|*/hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')))/*]]>*/</script>`;
+
+        // always remove new lines and trim the string before returning
+        return _return.replace(/\n/g, '').trim();
     });
 
     eleventyConfig.addShortcode("hubspotMeetings", (url) => {

--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,4 @@ _site/
 .eleventyignore
 .idea
 .github/
+.nvmrc

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ module.exports = function (eleventyConfig) {
     eleventyConfig.addPlugin(eleventyPluginHubspot, {
         portalId: 1234567,
         locale: "en",
+        loadingMode: "default",
         cssRequired: "",
         cssClass: "",
         translations: {
@@ -94,6 +95,7 @@ and
 {% hubspotForm "e3595481-9ab1-4d00-a98d-1a96a50058ad", {
     portalId: 1234567,
     locale: "en",
+    loadingMode: "lazy",
     cssRequired: "",
     cssClass: ""
 } %}
@@ -110,28 +112,29 @@ Type legend:
     C - (callback) A callback function that will be executed at various points in the form's lifecycle.
 
 
-| Attribute | Types | Description |
-|:----------|:-----:|:------------|
-| portalId | R, I | User's portal ID |
-| formId | R, I | Unique ID of the form you wish to build |
-| target | O | jQuery style selector specifying an existing element on the page into which the form will be placed once built. NOTE: If you're including multiple forms on the page, it is strongly recommended that you include a separate, specific target for each form. |
-| redirectUrl | O, I | URL to which the form will redirect upon a successful form completion. Cannot be used with inlineMessage. |
-| inlineMessage | O, I | Inline message to display in place of the form upon a successful form completion. Cannot be used with redirectUrl. |
-| pageId | O, I | ID of the landing page on which the form exists. This must be the content ID of a landing page built in HubSpot. |
-| cssRequired | O, I | CSS string specific to validation error messages and form styling. Empty string == no style. Note: when setting/declaring this field in the embed code, elements of your form will no longer have default HubSpot styling applied. |
-| cssClass | O | CSS class that will be applied to the form. |
-| submitButtonClass | O, I | CSS class that will be applied to the submit input instead of the default .hs-button.primary.large. |
-| errorClass | O, I | CSS class that will be applied to inputs with validation errors instead of the default .invalid.error. |
-| errorMessageClass | O, I | CSS class that will be applied to error messages instead of the default .hs-error-msgs.inputs-list. |
-| groupErrors | O | Show all errors at once inside a single container. Defaults to true, otherwise only shows the first error for each field. |
-| locale | O | Locale for the form, used to customize language for form errors and the date picker. See Add internationalized error messages below. |
-| translations | O | An object containing additional translation languages or to override field labels or messages for existing languages. See Customize internationalization below. |
-| manuallyBlockedEmailDomain | O, I | Array of domains to block in email inputs. |
-| formInstanceId | O, I | When embedding the same form on the same page twice, provide this Id for each identical form embed. The Id value is arbitrary, so long as it is not the same between forms. |
-| onBeforeFormInit | O, C | Callback that executes before the form builds, takes form configuration object as single argument: onBeforeFormInit(ctx) |
-| onFormReady | O, C | Callback that executes after form is built, placed in the DOM, and validation has been initialized. This is perfect for any logic that needs to execute when the form is on the page. Takes the jQuery form object as the argument: onFormReady($form) |
-| onFormSubmit | O, C | Callback that executes after form is validated, just before the data is actually sent. This is for any logic that needs to execute during the submit. Any changes will not be validated. Takes the jQuery form object as the argument: onFormSubmit($form). Note: Performing a browser redirect in this callback is not recommended and could prevent the form submission |
-| onFormSubmitted | O, C | Callback the data is actually sent.This allows you to perform an action when the submission is fully complete, such as displaying a confirmation or thank you message. |
+| Attribute                  | Types | Description                                                                                                                                                                                                                                                                                                                                                               |
+|:---------------------------|:-----:|:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| loadingMode                |   O   | The loading mode for the form. Options are `default`, `eager` and `lazy`. Default is `default`.                                                                                                                                                                                                                                                                           |
+| portalId                   | R, I  | User's portal ID                                                                                                                                                                                                                                                                                                                                                          |
+| formId                     | R, I  | Unique ID of the form you wish to build                                                                                                                                                                                                                                                                                                                                   |
+| target                     |   O   | jQuery style selector specifying an existing element on the page into which the form will be placed once built. NOTE: If you're including multiple forms on the page, it is strongly recommended that you include a separate, specific target for each form.                                                                                                              |
+| redirectUrl                | O, I  | URL to which the form will redirect upon a successful form completion. Cannot be used with inlineMessage.                                                                                                                                                                                                                                                                 |
+| inlineMessage              | O, I  | Inline message to display in place of the form upon a successful form completion. Cannot be used with redirectUrl.                                                                                                                                                                                                                                                        |
+| pageId                     | O, I  | ID of the landing page on which the form exists. This must be the content ID of a landing page built in HubSpot.                                                                                                                                                                                                                                                          |
+| cssRequired                | O, I  | CSS string specific to validation error messages and form styling. Empty string == no style. Note: when setting/declaring this field in the embed code, elements of your form will no longer have default HubSpot styling applied.                                                                                                                                        |
+| cssClass                   |   O   | CSS class that will be applied to the form.                                                                                                                                                                                                                                                                                                                               |
+| submitButtonClass          | O, I  | CSS class that will be applied to the submit input instead of the default .hs-button.primary.large.                                                                                                                                                                                                                                                                       |
+| errorClass                 | O, I  | CSS class that will be applied to inputs with validation errors instead of the default .invalid.error.                                                                                                                                                                                                                                                                    |
+| errorMessageClass          | O, I  | CSS class that will be applied to error messages instead of the default .hs-error-msgs.inputs-list.                                                                                                                                                                                                                                                                       |
+| groupErrors                |   O   | Show all errors at once inside a single container. Defaults to true, otherwise only shows the first error for each field.                                                                                                                                                                                                                                                 |
+| locale                     |   O   | Locale for the form, used to customize language for form errors and the date picker. See Add internationalized error messages below.                                                                                                                                                                                                                                      |
+| translations               |   O   | An object containing additional translation languages or to override field labels or messages for existing languages. See Customize internationalization below.                                                                                                                                                                                                           |
+| manuallyBlockedEmailDomain | O, I  | Array of domains to block in email inputs.                                                                                                                                                                                                                                                                                                                                |
+| formInstanceId             | O, I  | When embedding the same form on the same page twice, provide this Id for each identical form embed. The Id value is arbitrary, so long as it is not the same between forms.                                                                                                                                                                                               |
+| onBeforeFormInit           | O, C  | Callback that executes before the form builds, takes form configuration object as single argument: onBeforeFormInit(ctx)                                                                                                                                                                                                                                                  |
+| onFormReady                | O, C  | Callback that executes after form is built, placed in the DOM, and validation has been initialized. This is perfect for any logic that needs to execute when the form is on the page. Takes the jQuery form object as the argument: onFormReady($form)                                                                                                                    |
+| onFormSubmit               | O, C  | Callback that executes after form is validated, just before the data is actually sent. This is for any logic that needs to execute during the submit. Any changes will not be validated. Takes the jQuery form object as the argument: onFormSubmit($form). Note: Performing a browser redirect in this callback is not recommended and could prevent the form submission |
+| onFormSubmitted            | O, C  | Callback the data is actually sent.This allows you to perform an action when the submission is fully complete, such as displaying a confirmation or thank you message.                                                                                                                                                                                                    |
 
 
 

--- a/README.md
+++ b/README.md
@@ -77,10 +77,7 @@ and
 into HTML code like this:
 
 ```html
-<!--[if lte IE 8]>
-<script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2-legacy.js"></script>
-<![endif]-->
-<script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/v2.js"></script>
+<script charset="utf-8" type="text/javascript" src="//js.hsforms.net/forms/embed/v2.js"></script>
 <script data-hubspot-rendered="true">hbspt.forms.create({"portalId":1234567,"locale":"en","translations":{"en":{"invalidEmail":"Please enter a valid business email."}},"formId":"e3595481-9ab1-4d00-a98d-1a96a50058ad"});</script>
 ```
 and
@@ -136,7 +133,11 @@ Type legend:
 | onFormSubmit               | O, C  | Callback that executes after form is validated, just before the data is actually sent. This is for any logic that needs to execute during the submit. Any changes will not be validated. Takes the jQuery form object as the argument: onFormSubmit($form). Note: Performing a browser redirect in this callback is not recommended and could prevent the form submission |
 | onFormSubmitted            | O, C  | Callback the data is actually sent.This allows you to perform an action when the submission is fully complete, such as displaying a confirmation or thank you message.                                                                                                                                                                                                    |
 
+### Loading modes
 
+- `default` - The form will load when the page loads (Like you use HubSpot code directly).
+- `eager` - The form will load when DOMContentLoaded event is fired.
+- `lazy` - The form will load when it is in the viewport.
 
 
 ## Contributing

--- a/demo/.eleventy.js
+++ b/demo/.eleventy.js
@@ -6,8 +6,11 @@ module.exports = function (eleventyConfig) {
      * @link https://legacydocs.hubspot.com/docs/methods/forms/advanced_form_options
      */
     eleventyConfig.addPlugin(eleventyPluginHubspot, {
-        portalId: 8768191,
+        region: "na1",
+        portalId: "45442241",
         locale: "en",
+        loadingMode: "eager",
+        // loadingMode: "lazy",
         //cssRequired: "",
         //cssClass: "",
         translations: {

--- a/demo/index.njk
+++ b/demo/index.njk
@@ -33,12 +33,17 @@
                 <div class="pure-g">
                     <div class="pure-u-1-1">
 
-                        {% hubspotForm "6047c911-ee99-4cf6-942b-b42db681f005", {
+                        {% hubspotForm "f4e72b0a-fbd9-4ab3-938d-debdbdb7ea6e", {
                             locale: "es"
                         } %}
 
 
-                        {% hubspotForm "6047c911-ee99-4cf6-942b-b42db681f005", {
+                        {% hubspotForm "82b488a3-4a86-4f03-9e45-02f7d82c23ea", {
+                            locale: "es"
+                        } %}
+
+
+                        {% hubspotForm "160a18ba-dd02-4194-9da6-095ccee2ba87", {
                             locale: "es"
                         } %}
 
@@ -46,6 +51,11 @@
                         {# TODO findout how to pass event callback functions like onBeforeFormInit #}
 
                         {% hubspotMeetings "https://meetings.hubspot.com/alex-zappa" %}
+
+
+                        {% hubspotForm "f4e72b0a-fbd9-4ab3-938d-debdbdb7ea6e", {
+                            locale: "es"
+                        } %}
 
                     </div>
                 </div>

--- a/demo/lazy.md
+++ b/demo/lazy.md
@@ -1,0 +1,47 @@
+---
+permalink: /lazy/
+---
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>11ty Plugin HubSpot - Demo</title>
+    <link rel="stylesheet"
+          href="https://unpkg.com/purecss@2.1.0/build/pure-min.css"
+          integrity="sha384-yHIFVG6ClnONEA5yB5DJXfW2/KC173DIQrYoZMEtBvGzmf0PKiGyNEqe9N6BNDBH"
+          crossorigin="anonymous">
+    <style>
+        body {
+            background: #fafafa;
+        }
+        .page-wrapper {
+            background: #fff;
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 30px;
+            box-shadow: 0 5px 20px rgba(0,0,0,.15);
+        }
+        fieldset {
+            border: none;
+        }
+    </style>
+</head>
+<body>
+
+<div class="" style="min-height: 150vh; background-image: linear-gradient(120deg, #f6d365 0%, #fda085 100%);">
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque tempor, lacus lacus ornare ante, ac egestas est urna sit amet arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Sed molestie augue sit amet leo consequat posuere. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin vel ante a orci tempus eleifend ut et magna. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui, a portt
+</div>
+
+{% hubspotForm "f4e72b0a-fbd9-4ab3-938d-debdbdb7ea6e" %}
+{% hubspotForm "82b488a3-4a86-4f03-9e45-02f7d82c23ea" %}
+{% hubspotForm "160a18ba-dd02-4194-9da6-095ccee2ba87" %}
+
+{# TODO findout how to pass event callback functions like onBeforeFormInit #}
+
+{% hubspotMeetings "https://meetings.hubspot.com/alex-zappa" %}
+
+{% hubspotForm "f4e72b0a-fbd9-4ab3-938d-debdbdb7ea6e" %}
+
+
+
+</body>
+</html>

--- a/demo/mark.md
+++ b/demo/mark.md
@@ -1,12 +1,43 @@
 ---
-permalink: /demo/
+permalink: /mark/
 ---
-{% hubspotForm "6047c911-ee99-4cf6-942b-b42db681f005" %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>11ty Plugin HubSpot - Demo</title>
+    <link rel="stylesheet"
+          href="https://unpkg.com/purecss@2.1.0/build/pure-min.css"
+          integrity="sha384-yHIFVG6ClnONEA5yB5DJXfW2/KC173DIQrYoZMEtBvGzmf0PKiGyNEqe9N6BNDBH"
+          crossorigin="anonymous">
+    <style>
+        body {
+            background: #fafafa;
+        }
+        .page-wrapper {
+            background: #fff;
+            max-width: 960px;
+            margin: 0 auto;
+            padding: 30px;
+            box-shadow: 0 5px 20px rgba(0,0,0,.15);
+        }
+        fieldset {
+            border: none;
+        }
+    </style>
+</head>
+<body>
 
-
-{% hubspotForm "6047c911-ee99-4cf6-942b-b42db681f005" %}
-
+{% hubspotForm "f4e72b0a-fbd9-4ab3-938d-debdbdb7ea6e" %}
+{% hubspotForm "82b488a3-4a86-4f03-9e45-02f7d82c23ea" %}
+{% hubspotForm "160a18ba-dd02-4194-9da6-095ccee2ba87" %}
 
 {# TODO findout how to pass event callback functions like onBeforeFormInit #}
 
 {% hubspotMeetings "https://meetings.hubspot.com/alex-zappa" %}
+
+{% hubspotForm "f4e72b0a-fbd9-4ab3-938d-debdbdb7ea6e" %}
+
+
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": ".eleventy.js",
   "scripts": {
     "build": "cd demo/; npx eleventy",
-    "dev": "cd demo/; npx eleventy --serve",
+    "dev": "cd demo/; rm -rf _site/; npx eleventy --serve",
     "test": "cd demo/; npx eleventy"
   },
   "repository": {


### PR DESCRIPTION
@avree would you please check PR, will that work in you r markdown cases?
I found that we can encapsulate JS with `/* <![CDATA[| */` ...  `/* ]]> */` 😎

I also included lazy loading for the form, so that we can load the scripts and form itself when it comes into viewport.