### PR TITLE
Refactor undefined check for hbspt.forms.create

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -88,7 +88,7 @@ module.exports = (eleventyConfig, options = {}) => {
                 if (e.data === "hsFormsEmbedLoaded") {
                     w.removeEventListener("message", cb);
                     const interval = setInterval(function() {
-                        if (hbspt?.forms?.create && typeof hbspt.forms.create === 'function') {
+                        if ( typeof ((hbspt||{}).forms||{}).create === 'function' ) {
                             clearInterval(interval);
                             hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')));
                         }


### PR DESCRIPTION
Updated the conditional check to handle potential undefined `hbspt` and `forms` objects more robustly using optional chaining and default object assignment. This change ensures that `hbspt` and `forms` are defined before accessing the `create` function.