### PR TITLE
Refactor null-check for hbspt object.

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -127,7 +127,7 @@ module.exports = (eleventyConfig, options = {}) => {
                 if (e.data === "hsFormsEmbedLoaded") {
                     w.removeEventListener("message", cb);
                     const interval = setInterval(function() {
-                        if (hbspt?.forms?.create && typeof hbspt.forms.create === 'function') {
+                        if ( typeof ((hbspt||{}).forms||{}).create === 'function' ) {
                             clearInterval(interval);
                             hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')));
                         }
@@ -165,7 +165,7 @@ module.exports = (eleventyConfig, options = {}) => {
         window.addEventListener("message", function(e) {
             if (e.data === "hsFormsEmbedLoaded") {
                 const interval = setInterval(function() {
-                    if (hbspt?.forms?.create && typeof hbspt.forms.create === 'function') {
+                    if ( typeof ((hbspt||{}).forms||{}).create === 'function' ) {
                         clearInterval(interval);
                         hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')));
                     }


### PR DESCRIPTION
Replaced optional chaining with traditional null-check in two instances. This change increases compatibility with environments that do not support optional chaining.