### PR TITLE
Improve HubSpot forms creation check

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -88,7 +88,7 @@ module.exports = (eleventyConfig, options = {}) => {
                 if (e.data === "hsFormsEmbedLoaded") {
                     w.removeEventListener("message", cb);
                     const interval = setInterval(function() {
-                        if ( typeof ((hbspt||{}).forms||{}).create === 'function' ) {
+                        if ( typeof hbspt !== "undefined" && typeof ((hbspt||{}).forms||{}).create === 'function' ) {
                             clearInterval(interval);
                             hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')));
                         }
@@ -127,7 +127,7 @@ module.exports = (eleventyConfig, options = {}) => {
                 if (e.data === "hsFormsEmbedLoaded") {
                     w.removeEventListener("message", cb);
                     const interval = setInterval(function() {
-                        if ( typeof ((hbspt||{}).forms||{}).create === 'function' ) {
+                        if ( typeof hbspt !== "undefined" && typeof ((hbspt||{}).forms||{}).create === 'function' ) {
                             clearInterval(interval);
                             hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')));
                         }
@@ -165,7 +165,7 @@ module.exports = (eleventyConfig, options = {}) => {
         window.addEventListener("message", function(e) {
             if (e.data === "hsFormsEmbedLoaded") {
                 const interval = setInterval(function() {
-                    if ( typeof ((hbspt||{}).forms||{}).create === 'function' ) {
+                    if ( typeof hbspt !== "undefined" && typeof ((hbspt||{}).forms||{}).create === 'function' ) {
                         clearInterval(interval);
                         hbspt.forms.create(JSON.parse(decodeURIComponent('${encodedConfig}')));
                     }


### PR DESCRIPTION
Ensure `hbspt` is defined before accessing its forms creation function. This change prevents potential runtime errors when `hbspt` is not loaded, enhancing the reliability of the forms embedding process.